### PR TITLE
[Problem] Add rstrip all lines for uploaded test cases

### DIFF
--- a/problem/views/admin.py
+++ b/problem/views/admin.py
@@ -33,17 +33,6 @@ from ..utils import TEMPLATE_BASE, build_problem_template
 
 
 class TestCaseZipProcessor(object):
-    def _rstrip_content(self, byte_content):
-        '''
-        - strip trailing space for each line in answer file
-        - note that judge-server should strip the user output in the same way so that the
-            hash will be identical
-        '''
-        stream = io.StringIO(byte_content.decode())
-        stripped_lines = [line.rstrip() for line in stream.readlines()]
-        byte_content = '\n'.join(stripped_lines).encode()
-        return byte_content
-
     def process_zip(self, uploaded_zip_file, spj, dir=""):
         try:
             zip_file = zipfile.ZipFile(uploaded_zip_file, "r")
@@ -64,7 +53,12 @@ class TestCaseZipProcessor(object):
 
         for item in test_case_list:
             with open(os.path.join(test_case_dir, item), "wb") as f:
-                content = self._rstrip_content(zip_file.read(f"{dir}{item}"))
+                '''
+                - strip trailing space for each line in IO files
+                - note that judge-server should strip the files in the same way so that the
+                  hash will be identical
+                '''
+                content = b'\n'.join([line.rstrip() for line in zip_file.read(f"{dir}{item}").split(b'\n')])
                 size_cache[item] = len(content)
                 if item.endswith(".out"):
                     md5_cache[item] = hashlib.md5(content.rstrip()).hexdigest()

--- a/problem/views/admin.py
+++ b/problem/views/admin.py
@@ -1,4 +1,5 @@
 import hashlib
+import io
 import json
 import os
 # import shutil
@@ -32,6 +33,17 @@ from ..utils import TEMPLATE_BASE, build_problem_template
 
 
 class TestCaseZipProcessor(object):
+    def _rstrip_content(self, byte_content):
+        '''
+        - strip trailing space for each line in answer file
+        - note that judge-server should strip the user output in the same way so that the
+            hash will be identical
+        '''
+        stream = io.StringIO(byte_content.decode())
+        stripped_lines = [line.rstrip() for line in stream.readlines()]
+        byte_content = '\n'.join(stripped_lines).encode()
+        return byte_content
+
     def process_zip(self, uploaded_zip_file, spj, dir=""):
         try:
             zip_file = zipfile.ZipFile(uploaded_zip_file, "r")
@@ -52,7 +64,7 @@ class TestCaseZipProcessor(object):
 
         for item in test_case_list:
             with open(os.path.join(test_case_dir, item), "wb") as f:
-                content = zip_file.read(f"{dir}{item}").replace(b"\r\n", b"\n")
+                content = self._rstrip_content(zip_file.read(f"{dir}{item}"))
                 size_cache[item] = len(content)
                 if item.endswith(".out"):
                     md5_cache[item] = hashlib.md5(content.rstrip()).hexdigest()


### PR DESCRIPTION
This PR implemented the rstrip for each line in the uploaded test cases.

The way to process each line followed the idea of [2017 ICPC Hualien](https://github.com/mzshieh/tw-icpc-pc2/blob/master/validator/pc2val.py).  Each line of the user output or the answer was stored in a list after rstrip.  The two lists were then checked with `!=` operator.  Except that this PR joined the list for answer with `\n` and calculated its md5 hash,  in accordance with the original implementation of qdoj.

## Additional Notes

Note that this PR should work with [the modified JudgeServer](https://github.com/Redleaf23477/JudgeServer/commit/6d366f412a27689af1f49d9889d7aef3f5e4563b) so that the user output will be rstrip in the same manner as well.